### PR TITLE
Step2 を実装 `+` `-` ができるようになった

### DIFF
--- a/kcc.c
+++ b/kcc.c
@@ -7,10 +7,30 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  char *p = argv[1];
+
   printf(".intel_syntax noprefix\n");
   printf(".globl main\n");
   printf("main:\n");
-  printf("  mov rax, %d\n", atoi(argv[1]));
+  printf("  mov rax, %ld\n", strtol(p, &p, 10));
+
+  while (*p) {
+    if (*p == '+') {
+      p++;
+      printf("  add rax, %ld\n", strtol(p, &p, 10));
+      continue;
+    }
+
+    if (*p == '-') {
+      p++;
+      printf("  sub rax, %ld\n", strtol(p, &p, 10));
+      continue;
+    }
+
+    fprintf(stderr, "予期しない文字です: '%c'\n", *p);
+    return 1;
+  }
+  
   printf("  ret\n");
   return 0;
 }

--- a/test.sh
+++ b/test.sh
@@ -18,5 +18,6 @@ assert() {
 
 assert 0 0
 assert 42 42
+assert 21 "5+20-4"
 
 echo OK


### PR DESCRIPTION
# Note

- ref. [ステップ2：加減算のできるコンパイラの作成](https://www.sigbus.info/compilerbook#%E3%82%B9%E3%83%86%E3%83%83%E3%83%972%E5%8A%A0%E6%B8%9B%E7%AE%97%E3%81%AE%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%B3%E3%83%B3%E3%83%91%E3%82%A4%E3%83%A9%E3%81%AE%E4%BD%9C%E6%88%90)

# Log

- `strtol` 改めて調べておいた。 `man strtol` で見てみる。
  - 10はbaseなので基数を指してそう。
  - 二番目の引数 endptrには初めて数字ではない文字が登場した時その文字を指す。

manからの引用

> If endptr is not NULL, strtol() stores the address of the first  invalid  character  in
       *endptr.  If there were no digits at all, strtol() stores the original value of nptr in
       *endptr (and returns 0).  In particular, if *nptr is not '\0' but **endptr is  '\0'  on
       return, the entire string is valid.

- continueを使ってif-elseになるのを避けているのかな？この方が早期リターンっぽくて見やすいと感じた。