### PR TITLE
Step3 を実装 トークナイザ

### DIFF
--- a/kcc.c
+++ b/kcc.c
@@ -1,34 +1,139 @@
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
+// トークンの種類
+typedef enum
+{
+  TK_RESERVED, // 記号
+  TK_NUM,      // 整数トークン
+  TK_EOF,      // 入力の終わりを表すトークン
+} TokenKind;
+
+typedef struct Token Token;
+
+struct Token {
+  TokenKind kind; // トークンの型
+  Token *next; // 次の入力トークン
+  int val; // kindがTK_NUMの場合、その数値
+  char *str; // トークン文字列
+};
+
+// 現在着目しているトークン(globalに持つ)
+Token *token;
+
+// エラーを報告する
+// printfと同じ引数
+void error(char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  vfprintf(stderr, fmt, ap);
+  fprintf(stderr, "\n");
+  exit(1);
+}
+
+// 次のトークンが期待している記号 => トークン一つ読み進めてtrueを返却。
+// それ以外 => falseを返却。
+bool consume(char op) {
+  if (token->kind != TK_RESERVED || token->str[0] != op)
+    return false;
+  token = token->next;
+  return true;
+}
+
+// 次のトークンが期待している記号 => トークンを一つ読み進める。
+// それ以外 => エラー報告
+void expect(char op) {
+  if (token->kind != TK_RESERVED || token->str[0] != op)
+    error("'%c'ではありません", op);
+  token = token->next;
+}
+
+// 次のトークンが数値 => トークンを一つ読み進めてその数値を返す。
+// それ以外 => エラーを報告
+int expect_number() {
+  if (token->kind != TK_NUM)
+    error("数ではありません");
+  int val = token->val;
+  token = token->next;
+  return val;
+}
+
+bool at_eof() {
+  return token->kind == TK_EOF;
+}
+
+// 新しいトークンを作成してcurにつなげる
+// cur --> tok { kind: kind, str: str, next: NULL, val: NULL }
+Token *new_token(TokenKind kind, Token *cur, char *str) {
+  Token *tok = calloc(1, sizeof(Token));
+  tok->kind = kind;
+  tok->str = str;
+  cur->next = tok;
+  return tok;
+}
+
+// 入力文字列pをトークナイズしてトークナイズしたトークンを返す
+Token *tokenize(char *p) {
+  Token head;
+  head.next = NULL;
+  Token *cur = &head;
+
+  while (*p) {
+    if (isspace(*p)) {
+      p++;
+      continue;
+    }
+
+    if (*p == '+' || *p == '-') {
+      cur = new_token(TK_RESERVED, cur, p++);
+      continue;
+    }
+
+    if (isdigit(*p)) {
+      cur = new_token(TK_NUM, cur, p);
+      cur->val = strtol(p, &p, 10);
+      continue;
+    }
+
+    error("トークナイズできません");
+  }
+
+  new_token(TK_EOF, cur, p);
+  return head.next;
+}
 
 int main(int argc, char **argv) {
   if (argc != 2) {
-    fprintf(stderr, "引数の個数が正しくありません\n");
+    error("引数の個数が正しくありません");
     return 1;
   }
 
-  char *p = argv[1];
+  // トークナイズする
+  token = tokenize(argv[1]);
 
+  // アセンブリの前半部分を出力
   printf(".intel_syntax noprefix\n");
   printf(".globl main\n");
   printf("main:\n");
-  printf("  mov rax, %ld\n", strtol(p, &p, 10));
+  
+  // 最初は数でなければならない
+  // checkしてmov命令を出力
+  printf("  mov rax, %d\n", expect_number());
 
-  while (*p) {
-    if (*p == '+') {
-      p++;
-      printf("  add rax, %ld\n", strtol(p, &p, 10));
+  // `+ <num>`, `- <num>` というトークンの並びを消費
+  // アセンブリを出力
+  while (!at_eof()) {
+    if (consume('+')) {
+      printf("  add rax, %d\n", expect_number());
       continue;
     }
 
-    if (*p == '-') {
-      p++;
-      printf("  sub rax, %ld\n", strtol(p, &p, 10));
-      continue;
-    }
-
-    fprintf(stderr, "予期しない文字です: '%c'\n", *p);
-    return 1;
+    expect('-');
+    printf("  sub rax, %d\n", expect_number());  
   }
   
   printf("  ret\n");

--- a/test.sh
+++ b/test.sh
@@ -19,5 +19,6 @@ assert() {
 assert 0 0
 assert 42 42
 assert 21 "5+20-4"
+assert 41 " 12 + 34 - 5 "
 
 echo OK


### PR DESCRIPTION
# Note

zenn scrap: https://zenn.dev/link/comments/9e4231d44c0ce2 をまとめた。

## 1. typedef structの意味

```c
typedef struct Token Token;
```

```c
typedef defined_type new_type;
```

という構文で、これは以下のようにも書ける。

```c
typedef struct {
...
} new_type;
```

型と構造体で同じ名前にすることができる。今回だと、`struct Token` 内部で `Token` を型として使っているから先にtypedefしているのだろう。

## 2. グローバルにtokenを持つ理由

これはtokenを標準入力のようにストリームとして扱う方がすっきりするから(本文より間接引用)

## 3. エラーを報告する関数の引数

```c
void error(char *fmt, ...) { ... }
```

`...` は任意個数の引数が書ける。これとセットで使われるのが `va_list` や `va_start` や `va_arg` や `va_end` になる。

今回の処理だと、

```c
void error(char *fmt, ...) {
  va_list ap;
  va_start(ap, fmt);
  vfprintf(stderr, fmt, ap);
  fprintf(stderr, "\n");
  exit(1);
}
```

`va_list ap` で可変長引数の最初のポインタを `ap` に入れて、それを `va_start` を用いて、`ap` を初期化している。これで `ap` を `...` として扱えるようになったので、vfprintfも同じ引数形式なので入れることができている。


## 4. calloc

callocはmallocした領域を全ビット0埋めする。
