### PR TITLE
Step4 を実装 エラーメッセージの改良

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ kcc
 *.o
 a.out
 tmp*
+.vscode/

--- a/kcc.c
+++ b/kcc.c
@@ -22,6 +22,9 @@ struct Token {
   char *str; // トークン文字列
 };
 
+// 入力プログラム
+char *user_input;
+
 // 現在着目しているトークン(globalに持つ)
 Token *token;
 
@@ -30,6 +33,20 @@ Token *token;
 void error(char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
+  vfprintf(stderr, fmt, ap);
+  fprintf(stderr, "\n");
+  exit(1);
+}
+
+// エラー箇所を報告する
+void error_at(char *loc, char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+
+  int pos = loc - user_input;
+  fprintf(stderr, "%s\n", user_input);
+  fprintf(stderr, "%*s", pos, " "); // pos個の空白を出力
+  fprintf(stderr, "^ ");
   vfprintf(stderr, fmt, ap);
   fprintf(stderr, "\n");
   exit(1);
@@ -48,7 +65,7 @@ bool consume(char op) {
 // それ以外 => エラー報告
 void expect(char op) {
   if (token->kind != TK_RESERVED || token->str[0] != op)
-    error("'%c'ではありません", op);
+    error_at(token->str, "'%c'ではありません", op);
   token = token->next;
 }
 
@@ -56,7 +73,7 @@ void expect(char op) {
 // それ以外 => エラーを報告
 int expect_number() {
   if (token->kind != TK_NUM)
-    error("数ではありません");
+    error_at(token->str, "数ではありません");
   int val = token->val;
   token = token->next;
   return val;
@@ -77,7 +94,8 @@ Token *new_token(TokenKind kind, Token *cur, char *str) {
 }
 
 // 入力文字列pをトークナイズしてトークナイズしたトークンを返す
-Token *tokenize(char *p) {
+Token *tokenize() {
+  char *p = user_input;
   Token head;
   head.next = NULL;
   Token *cur = &head;
@@ -99,7 +117,7 @@ Token *tokenize(char *p) {
       continue;
     }
 
-    error("トークナイズできません");
+    error_at(p, "トークナイズできません");
   }
 
   new_token(TK_EOF, cur, p);
@@ -112,8 +130,9 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  user_input = argv[1];
   // トークナイズする
-  token = tokenize(argv[1]);
+  token = tokenize();
 
   // アセンブリの前半部分を出力
   printf(".intel_syntax noprefix\n");


### PR DESCRIPTION
# Note

https://zenn.dev/link/comments/c875c9c8f9a10c

## 1. fprintfの `*` の意味

```c
fprintf(stderr, "%*s", pos, " "); // pos個の空白を出力
```

 `*` とwidthを用いて幅を指定できる。今回だと、posがwidthに当たる。